### PR TITLE
fix: wrong abi for mainnet + % MAX fix

### DIFF
--- a/components/sections/bridgesection.tsx
+++ b/components/sections/bridgesection.tsx
@@ -35,7 +35,7 @@ import { toast } from "@/components/ui/use-toast";
 import { parseError } from "@/utils/parseError";
 import BigNumber from "bignumber.js";
 import { badgeVariants } from "../ui/badge";
-import { ArrowUpRight, CheckCircle2, Copy, Loader2 } from "lucide-react";
+import { ArrowUpRight, CheckCircle2, Copy, InfoIcon, Loader2 } from "lucide-react";
 import useTransactions from "@/hooks/useTransactions";
 import { parseAmount } from "@/utils/parseAmount";
 import { LoadingButton } from "../ui/loadingbutton";
@@ -66,6 +66,8 @@ import {
   DialogTitle,
 } from "../ui/dialog";
 import { Button } from "../ui/button";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "../ui/hover-card";
+import { CiCircleQuestion } from "react-icons/ci";
 
 const formSchema = z.object({
   fromAmount: z.preprocess(
@@ -519,9 +521,16 @@ export default function BridgeSection() {
                                     value && form.setValue("fromAmount", value);
                                     setFromAmount(value);
                                   }}
-                                  className="font-thicccboisemibold text-[#3FB5F8] text-sm cursor-pointer"
+                                  className="font-thicccboisemibold flex flex-row space-x-1 text-[#3FB5F8] text-sm cursor-pointer"
                                 >
-                                  MAX
+                                  <span>MAX</span> <HoverCard>
+              <HoverCardTrigger className="cursor-pointer">
+                <InfoIcon className="w-3 h-3 " />
+              </HoverCardTrigger>
+              <HoverCardContent className="font-thicccboisemibold text-white text-opacity-70">
+              Transfers the max available minus 1 AVAIL reserved to pay fees
+              </HoverCardContent>
+            </HoverCard>
                                 </div>
                               </div>
                             </div>

--- a/components/sections/bridgesection.tsx
+++ b/components/sections/bridgesection.tsx
@@ -508,12 +508,12 @@ export default function BridgeSection() {
                                     const value =
                                       fromChain === Chain.ETH
                                         ? ethBalance
-                                          ? parseFloat(ethBalance) * 0.98
+                                          ? parseFloat(parseAmount(ethBalance, 18) )
                                           : 0
                                         : availBalance
                                         ? parseFloat(
                                             parseAmount(availBalance, 18)
-                                          ) * 0.98
+                                          ) - 1
                                         : 0;
 
                                     value && form.setValue("fromAmount", value);

--- a/hooks/useClaim.ts
+++ b/hooks/useClaim.ts
@@ -2,6 +2,9 @@ import { writeContract } from "@wagmi/core";
 import { encodeAbiParameters } from "viem";
 import { merkleProof } from "@/types/transaction";
 import { bridgeContractAbi } from "@/constants/abi";
+import ethereumBrigdeMainnet from "@/constants/abis/ethereumBridgeMainnet.json";
+import ethereumBridgeTuring from "@/constants/abis/ethereumBridgeTuring.json";
+
 import { config } from "@/app/providers";
 import {
   fetchLatestBlockhash,
@@ -33,7 +36,7 @@ export default function useClaim() {
       //@ts-ignore config gives a wagmi dep type error
       const result = await writeContract(config, {
         address: process.env.NEXT_PUBLIC_BRIDGE_PROXY_CONTRACT,
-        abi: bridgeContractAbi,
+        abi: process.env.NEXT_PUBLIC_ETHEREUM_NETWORK === "mainnet" ? ethereumBrigdeMainnet : ethereumBridgeTuring,
         functionName: "receiveAVAIL",
         args: [
           [


### PR DESCRIPTION
- in `receiveAvail()` the abi wasn't being switched according to chain like other places where abis + contracts are being used, this might be the root cause of claims from avail -> eth failing for people.

-  fixed the %MAX issue 