### PR TITLE
release: floating support button with Discord modal

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { FooterSection } from "@/components/ui/FooterSection/FooterSection";
 import { Footer } from "@/components/ui/Footer/Footer";
 import DatadogInit from "./datadog-init";
 import { Analytics } from "@vercel/analytics/react";
+import { SupportButton } from "@/components/ui/SupportButton/SupportButton";
 
 
 export const metadata: Metadata = {
@@ -32,6 +33,7 @@ export default async function RootLayout({
            <Toaster />
           <FooterSection title={"Accelerating the unification of web3"} description={"DA Mainnet is now live!"}/>
           <Footer />
+          <SupportButton />
           </Providers>
       </body>
     </html>

--- a/components/ui/SupportButton/SupportButton.tsx
+++ b/components/ui/SupportButton/SupportButton.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { useState } from "react";
+import { MessageCircleQuestion } from "lucide-react";
+
+export function SupportButton() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        aria-label="Support"
+        className="fixed bottom-6 right-6 z-50 flex items-center gap-2 rounded-full bg-gradient-to-r from-[#2778E9] to-[#439FE7] px-4 py-3 text-sm font-semibold text-white shadow-lg transition-transform hover:scale-105 focus:outline-none"
+      >
+        <MessageCircleQuestion className="h-4 w-4 shrink-0" />
+        <span>Support</span>
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-sm bg-[#0d1117] border border-gray-700 text-white rounded-2xl px-8 py-8">
+          <DialogHeader>
+            <div className="flex items-center gap-3 mb-2">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-[#2778E9] to-[#439FE7]">
+                <MessageCircleQuestion className="h-5 w-5 text-white" />
+              </div>
+              <DialogTitle className="text-white text-lg font-semibold">
+                Need Help?
+              </DialogTitle>
+            </div>
+            <DialogDescription className="text-gray-300 text-sm leading-relaxed pt-1">
+              If you face any issue, create a ticket on{" "}
+              <a
+                href="https://discord.com/invite/AvailProject"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-[#439FE7] underline underline-offset-2 hover:text-white transition-colors"
+              >
+                Avail Discord
+              </a>
+              {" "}and our team will get back to you as soon as possible.
+            </DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Promotes staging → main.

Includes:
- **feat: add floating support button with Discord modal** (#120) — adds a fixed bottom-right "Support" button that opens a modal directing users to [Avail Discord](https://discord.com/invite/AvailProject) when they face issues.

## Test plan

- [ ] Support button visible at bottom-right on [bridge.availproject.org](https://bridge.availproject.org)
- [ ] Clicking opens the modal with a working Avail Discord hyperlink
- [ ] Modal dismisses via X or clicking outside
