### PR TITLE
security: bump shell-quote to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
       "@wormhole-foundation/sdk-definitions": "^3.12.0",
       "@wormhole-foundation/sdk-connect": "^3.12.0",
       "axios": ">=1.15.0",
-      "motion-dom": "12.0.0"
+      "motion-dom": "12.0.0",
+      "shell-quote": "1.8.4"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   '@wormhole-foundation/sdk-connect': ^3.12.0
   axios: '>=1.15.0'
   motion-dom: 12.0.0
+  shell-quote: 1.8.4
 
 dependencies:
   '@avail-project/metamask-avail-types':
@@ -12080,7 +12081,7 @@ packages:
   /react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
     dependencies:
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
@@ -12783,8 +12784,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  /shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  /shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
     dev: false
 


### PR DESCRIPTION
## Summary
- add a pnpm override for shell-quote@1.8.4
- refresh pnpm-lock.yaml so react-devtools-core resolves the patched shell-quote release

## Dependency path
- shell-quote is not imported by app source
- production transitive path: connectkit/wagmi -> @wagmi/connectors -> @metamask/sdk -> react-native -> react-devtools-core -> shell-quote

## Validation
- pnpm install --lockfile-only
- pnpm install --frozen-lockfile
- pnpm why shell-quote --prod now resolves shell-quote@1.8.4
- pnpm audit --prod --json check reports 0 shell-quote advisories
- pnpm lint passes with existing react-hooks warnings
- pnpm build passes with existing react-hooks warnings and non-fatal missing COINGECKO_API_KEY log during static generation

Note: pnpm audit still reports unrelated pre-existing critical advisories in cipher-base, elliptic, pbkdf2, and protobufjs from the Wormhole/CosmJS dependency tree.